### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.12
+
+LABEL maintainer ""
+
+# Add project source
+COPY ubi_serial_hack.py /usr/bin/ubi_serial_hack
+
+# Install dependencies
+RUN apk update \
+&& apk add --no-cache \
+  python3 \
+  py3-paramiko \
+  py3-scp
+
+ENTRYPOINT ["ubi_serial_hack"]


### PR DESCRIPTION
A made a quick Dockerfile to run ubi_serial_hack from the command line without installing anything locally:

```sh
docker run --rm <container_image> -r 192.168.1.1 -p 22 --serial 48:57:54:43:30:30:30:30
```